### PR TITLE
Update to support groovy projects

### DIFF
--- a/src/main/groovy/naedward/gradle/coverityplugin/tasks/EmitTask.groovy
+++ b/src/main/groovy/naedward/gradle/coverityplugin/tasks/EmitTask.groovy
@@ -27,10 +27,10 @@ class EmitTask extends DefaultTask {
             coverityClasspath.plus(diff)
          }
 
-         Set<File> coveritySrc = project.sourceSets.main.java.srcDirs
+         Set<File> coveritySrc = project.sourceSets.main.allJava.srcDirs
 
          if (project.coverity.includeTestSource) {
-            coveritySrc.addAll(project.sourceSets.test.java.srcDirs)
+            coveritySrc.addAll(project.sourceSets.test.allJava.srcDirs)
          }
 
          String pathSep = File.pathSeparator
@@ -40,6 +40,7 @@ class EmitTask extends DefaultTask {
                   continue
                }
             }
+            if (!dir.exists()) continue
             sourcePaths.append(dir.getCanonicalPath());
             sourcePaths.append(pathSep);
          }


### PR DESCRIPTION
2 issues were identified that caused this plugin to fail
when run on groovy projects.
- Java sources under the groovy sourceSet are ignored
  
  Groovy projects may contain java sources in the groovy sourceSet
  for joint compilation.  These java files are ignored by the plugin.
- Java sourceSet directory might not exist
  
  A groovy project might put all of its java source under the groovy
  sourceSet and use joint compilation. If any sourceSets.main.java.srcDirs
  do not exist, then the cov-emit-java task will fail.
